### PR TITLE
fix: Change file extension of ESM entry point to `.mjs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "2.0.0",
   "description": "Nextcloud helpers related to authentication and the current user",
   "main": "dist/index.js",
-  "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "exports": {
-    "import": "./dist/index.esm.js",
-    "require": "./dist/index.js"
+    "import": "./dist/index.es.mjs",
+    "require": "./dist/index.js",
+    "types": "./dist/index.d.ts"
   },
   "files": [
     "dist/"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,7 +26,7 @@ export default [
     plugins: [typescript()],
     output: [
       {
-        file: 'dist/index.esm.js',
+        file: 'dist/index.es.mjs',
         format: 'esm',
         sourcemap: true,
       },


### PR DESCRIPTION
Current package type is CommonJS so node interprets every `.js` file as CommonJS even if exports lists the file as ESM.

To prevent this the file has to be named `.mjs`.