### PR TITLE
feat: Initialize cached values later

### DIFF
--- a/lib/requesttoken.ts
+++ b/lib/requesttoken.ts
@@ -1,18 +1,31 @@
 import { subscribe } from '@nextcloud/event-bus'
 
-const tokenElement = document.getElementsByTagName('head')[0]
-let token = tokenElement ? tokenElement.getAttribute('data-requesttoken') : null
-
 export interface CsrfTokenObserver {
 	(token: string): void;
 }
 
+let token: string | null | undefined = undefined
 const observers: CsrfTokenObserver[] = []
 
+/**
+ * Get current request token
+ *
+ * @return {string|null} Current request token or null if not set
+ */
 export function getRequestToken(): string | null {
+	if (token === undefined) {
+		// Only on first load, try to get token from document
+		const tokenElement = document?.getElementsByTagName('head')[0]
+		token = tokenElement ? tokenElement.getAttribute('data-requesttoken') : null
+	}
 	return token
 }
 
+/**
+ * Add an observer which is called when the CSRF token changes
+ *
+ * @param observer The observer 
+ */
 export function onRequestTokenUpdate(observer: CsrfTokenObserver): void {
 	observers.push(observer)
 }

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -1,14 +1,8 @@
 /// <reference types="@nextcloud/typings" />
 
-declare var OC: Nextcloud.v16.OC
-	| Nextcloud.v17.OC
-	| Nextcloud.v18.OC
-	| Nextcloud.v19.OC
-	| Nextcloud.v20.OC
-	| Nextcloud.v21.OC
-	| Nextcloud.v22.OC
-	| Nextcloud.v20.OC
-	| Nextcloud.v24.OC;
+declare var OC: Nextcloud.v23.OC
+	| Nextcloud.v24.OC
+	| Nextcloud.v25.OC;
 
 const getAttribute = (el: HTMLHeadElement | undefined, attribute: string): string | null => {
 	if (el) {
@@ -18,13 +12,7 @@ const getAttribute = (el: HTMLHeadElement | undefined, attribute: string): strin
 	return null
 }
 
-const head = document.getElementsByTagName('head')[0]
-const uid = getAttribute(head, 'data-user')
-const displayName = getAttribute(head, 'data-user-displayname')
-
-const isAdmin = (typeof OC === 'undefined')
-	? false
-	: OC.isUserAdmin()
+let currentUser: NextcloudUser | null | undefined = undefined
 
 export interface NextcloudUser {
 	uid: string,
@@ -33,13 +21,27 @@ export interface NextcloudUser {
 }
 
 export function getCurrentUser(): NextcloudUser | null {
-	if (uid === null) {
+	if (currentUser !== undefined) {
+		return currentUser
+	}
+
+	const head = document?.getElementsByTagName('head')[0]
+	if (!head) {
 		return null
 	}
 
-	return {
+	// No user logged in so cache and return null
+	const uid = getAttribute(head, 'data-user')
+	if (uid === null) {
+		currentUser = null
+		return currentUser
+	}
+
+	currentUser = {
 		uid,
-		displayName,
-		isAdmin,
+		displayName: getAttribute(head, 'data-user-displayname'),
+		isAdmin: (typeof OC === 'undefined') ? false : OC.isUserAdmin(),
 	} as NextcloudUser
+
+	return currentUser
 }

--- a/test/request-token.test.js
+++ b/test/request-token.test.js
@@ -12,7 +12,7 @@ describe('request token', () => {
     })
 
     test('updates token via event', () => {
-        expect(getRequestToken()).toBe(undefined)
+        expect(getRequestToken()).toBe(null)
     })
 
     test('find correct value', () => {


### PR DESCRIPTION
Currently the current user and the csrf token are initialized when the file is loaded, but this will fail when imported in tests without DOM or for SSR (e.g. nextcloud-vue docs). So instead the cached values are loaded on the first usage.